### PR TITLE
Created Chat API to create chat for one to one chatting allowing only 2 members to join the chat. Added chat DTO, repository, service to create chat and find all chats by member id.

### DIFF
--- a/src/chats/chats.controller.spec.ts
+++ b/src/chats/chats.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatsController } from './chats.controller';
+import { ChatsService } from './chats.service';
+
+describe('ChatsController', () => {
+  let controller: ChatsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChatsController],
+      providers: [ChatsService],
+    }).compile();
+
+    controller = module.get<ChatsController>(ChatsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/chats/chats.controller.ts
+++ b/src/chats/chats.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Post, Body, Param, UseGuards } from '@nestjs/common';
+import { ChatsService } from './chats.service';
+import { CreateChatDto } from './dto/create-chat.dto';
+import { ApiTags, ApiResponse , ApiBearerAuth} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+
+@ApiBearerAuth('access-token')
+@ApiTags('chats')
+@Controller('chats')
+export class ChatsController {
+  constructor(private readonly chatsService: ChatsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post('create-chat')
+  @ApiResponse({
+    status: 201,
+    description: 'The chat has been successfully created.',
+  })
+  async createChat(@Body() createChatDto: CreateChatDto) {
+    return await this.chatsService.createChat(createChatDto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get(':id')
+  async getAllChatsByUserId(@Param(':id') id: string) {
+    return await this.chatsService.findAllChats(id);
+  }
+}

--- a/src/chats/chats.module.ts
+++ b/src/chats/chats.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { ChatsService } from './chats.service';
+import { ChatsController } from './chats.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ChatSchema, Chat } from 'src/_schemas/chat.schema';
+import { ChatsRepository } from './chats.repository';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Chat.name, schema: ChatSchema }]),
+  ],
+  controllers: [ChatsController],
+  providers: [ChatsService, ChatsRepository],
+  exports: [ChatsService],
+})
+export class ChatsModule {}

--- a/src/chats/chats.repository.ts
+++ b/src/chats/chats.repository.ts
@@ -1,0 +1,20 @@
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { ChatDo } from 'src/_schemas/chat.do';
+
+export class ChatsRepository {
+  constructor(
+    @InjectModel('Chat')
+    private chatModel: Model<ChatDo>,
+  ) {}
+
+  async createChat(chat): Promise<any> {
+    const createOne = await this.chatModel.create(chat);
+    return createOne;
+  }
+
+  async findAllChats(id): Promise<any> {
+    const findAll = await this.chatModel.find({ members: { $all: [id] } });
+    return findAll;
+  }
+}

--- a/src/chats/chats.service.spec.ts
+++ b/src/chats/chats.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatsService } from './chats.service';
+
+describe('ChatsService', () => {
+  let service: ChatsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ChatsService],
+    }).compile();
+
+    service = module.get<ChatsService>(ChatsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/chats/chats.service.ts
+++ b/src/chats/chats.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { CreateChatDto } from './dto/create-chat.dto';
+import { ChatsRepository } from './chats.repository';
+
+@Injectable()
+export class ChatsService {
+  constructor(private readonly chatsRepository: ChatsRepository) {}
+
+  async createChat(createChatDto: CreateChatDto) {
+    return await this.chatsRepository.createChat(createChatDto);
+  }
+
+  async findAllChats(id: string) {
+    return await this.chatsRepository.findAllChats(id);
+  }
+}

--- a/src/chats/dto/create-chat.dto.ts
+++ b/src/chats/dto/create-chat.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsArray , ArrayMinSize, ArrayMaxSize} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateChatDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsArray()
+  @ArrayMinSize(2)
+  @ArrayMaxSize(2)
+  members: Array<string>;
+}

--- a/src/chats/entities/chat.entity.ts
+++ b/src/chats/entities/chat.entity.ts
@@ -1,0 +1,1 @@
+export class Chat {}


### PR DESCRIPTION
Add chat module with chat DTO, controller, service, repository.
- Chat DTO allows an array of size 2 for two members to start a chat.
- Implemented ChatsRepository with methods to create and find chats.
  - `createChat(chat)`: Creates a new chat document.
  - `findAllChats(id)`: Retrieves all chats involving the specified member ID.
- Integrated Mongoose with NestJS to manage chat data.